### PR TITLE
Fix: Update tailwind.config.js to scan CSS files

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   content: [
     "./index.html",
-    "./src/**/*.{js,ts}"
+    "./src/**/*.{js,ts,css}" // Asegúrate de que Tailwind escanee archivos .css en src
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
- Se añadió '*.css' a la matriz de contenido en tailwind.config.js.
- Esto soluciona errores de compilación donde Tailwind no podía aplicar las clases de utilidad utilizadas con @apply en src/style.css porque no escaneaba los archivos CSS para detectar el uso de clases.
- Este cambio forma parte de la función de diseño del chat del iPhone.